### PR TITLE
added support for legacy transactions

### DIFF
--- a/contracts/SPVStore.sol
+++ b/contracts/SPVStore.sol
@@ -6,7 +6,7 @@ pragma solidity 0.4.25;
 import {ValidateSPV} from "./ValidateSPV.sol";
 import {BTCUtils} from "./BTCUtils.sol";
 import {BytesLib} from "./BytesLib.sol";
-import {SafeMath} from "./SafeMath.sol";
+import {SafeMath} from "../SafeMath.sol";
 
 
 contract SPVStore {
@@ -21,7 +21,7 @@ contract SPVStore {
     event TxStored(bytes32 indexed _txid);
     event HeaderStored(bytes32 indexed _digest);
 
-    enum OutputTypes { NONE, WPKH, WSH, OP_RETURN }
+    enum OutputTypes { NONE, WPKH, WSH, OP_RETURN, PKH, SH}
 
     struct TxIn {
         uint32 sequence;            // 4 byte sequence number
@@ -210,6 +210,10 @@ contract SPVStore {
                 _output.outputType = OutputTypes.WSH;
             } else if (_outputType == 3) {
                 _output.outputType = OutputTypes.OP_RETURN;
+            } else if (_outputType == 4) {
+                _output.outputType = OutputTypes.PKH;
+            } else if (_outputType == 5) {
+                _output.outputType = OutputTypes.SH;
             }
 
             transactions[_txid].outputs[i] = _output;

--- a/contracts/ValidateSPV.sol
+++ b/contracts/ValidateSPV.sol
@@ -148,13 +148,11 @@ library ValidateSPV {
     /// @return         Tx input sequence number, tx hash, and index
     function parseInput(bytes _input) public pure returns (uint32 _sequence, bytes32 _hash, uint32 _index) {
 
-        // Require segwit: if no 00 scriptSig, error
-        if (keccak256(_input.slice(36, 1)) != keccak256(hex'00')) { return; }
-
-        // Require that input is 41 bytes
-        if (_input.length != 41) { return; }
-
-        return (_input.extractSequence(), _input.extractTxId(), _input.extractTxIndex());
+        if (keccak256(_input.slice(36, 1)) == keccak256(hex'00') && (_input.length == 41) || 
+            keccak256(_input.slice(36, 1)) == keccak256(hex'17') && (_input.length == 64)) { 
+    
+                return (_input.extractSequence(), _input.extractTxId(), _input.extractTxIndex());
+            } else { return ; }
     }
 
     /// @notice         Parses a tx output from raw output bytes


### PR DESCRIPTION
Hey James, added legacy support so that it verifies p2sh-p2pwkh and p2sh-p2wsh!  
Also added a function to extract signature script
I tested it locally with the following transaction and it worked fine. Did not update your test file. 
      '0x0200000000010111b6e0460bb810b05744f8d38262f95fbab02b168b070598a6f31fad438fced4000000001716001427c106013c0042da165c082b3870c31fb3ab4683feffffff0200ca9a3b0000000017a914d8b6fcc85a383261df05423ddf068a8987bf0287873067a3fa0100000017a914d5df0b9ca6c0e1ba60a9ff29359d2600d9c6659d870247304402203b85cb05b43cc68df72e2e54c6cb508aa324a5de0c53f1bbfe997cbd7509774d022041e1b1823bdaddcd6581d7cde6e6a4c4dbef483e42e59e04dbacbaf537c3e3e8012103fbbdb3b3fc3abbbd983b20a557445fb041d6f21cc5977d2121971cb1ce5298978c000000'

Haven't tested the header tools yet and will update if something is breaking. 