### PR TITLE
test: vector for maliciously long witness scripts

### DIFF
--- a/solidity/contracts/BTCUtils.sol
+++ b/solidity/contracts/BTCUtils.sol
@@ -404,7 +404,7 @@ library BTCUtils {
     /// @return          The hash committed to by the pk_script, or null for errors
     function extractHash(bytes memory _output) internal pure returns (bytes memory) {
         if (uint8(_output.slice(9, 1)[0]) == 0) {
-            uint256 _len = uint8(extractOutputScriptLen(_output)[0]);
+            uint256 _len = uint8(_output[8]);
             if (_len < 2) {
               return hex"";
             }

--- a/testVectors.json
+++ b/testVectors.json
@@ -647,6 +647,27 @@
       "rustError": "Maliciously formatted witness output"
     },
     {
+      "comment": "Maliciously formatted witness output",
+      "input": "0x0000000000000000fd0001000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+      "jsError": "Maliciously formatted witness output",
+      "golangError": "Maliciously formatted witness output",
+      "rustError": "Maliciously formatted witness output"
+    },
+    {
+      "comment": "Maliciously formatted witness output",
+      "input": "0x0000000000000000220017",
+      "jsError": "Maliciously formatted witness output",
+      "golangError": "Maliciously formatted witness output",
+      "rustError": "Maliciously formatted witness output"
+    },
+    {
+      "comment": "Maliciously formatted witness output",
+      "input": "0x0000000000000000220017",
+      "jsError": "Maliciously formatted witness output",
+      "golangError": "Maliciously formatted witness output",
+      "rustError": "Maliciously formatted witness output"
+    },
+    {
       "comment": "Maliciously formatted p2pkh output",
       "input": "0x00000000000000001976a912",
       "jsError": "Maliciously formatted p2pkh output",


### PR DESCRIPTION
TODO: `extractOutputScriptLength` is busted. Remove or update to support varints